### PR TITLE
Remove default `shfmt` flags to respect `.editorconfig` file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   ### Flags for shfmt ###
   shfmt_flags:
     description: 'flags for shfmt'
-    default: '-i 2 -ci'
+    default: ''
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
The default `shfmt` flags `-i 2 -ci` have been removed to allow `shfmt` to respect the `.editorconfig` file when formatting shell scripts.

When default flags are specified, `shfmt` ignores the settings in `.editorconfig`, which can lead to inconsistencies in formatting. By setting the default to an empty string, users can now rely on `.editorconfig` for formatting configurations, or override the flags as needed.